### PR TITLE
change `.from` to `Symbol.from`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,15 +82,15 @@ match (input) {
 ## Construction Literals
 
 For construction, literals are a thin layer of syntax sugar over
-`Constructor.from()` functions. When a literal construction expression is found,
+`Constructor[Symbol.from]()` functions. When a literal construction expression is found,
 the left hand side is evaluated for its value, and the right hand side is
 converted to an iterator or an atomic value. The type of value passed to
-`.from()` depends on which of the three syntaxes is used:
+`[Symbol.from]()` depends on which of the three syntaxes is used:
 
 ```js
 // Tagged Object Literals
 Map!{foo: 1, 'foo': 1, [Symbol('bar')]: 2, 3: 4, [{}]: 5}
-=== Map.from({[Symbol.iterator]: function* () {
+=== Map[Symbol.from]({[Symbol.iterator]: function* () {
   // IdentifierName interpreted as string
   yield ['foo', 1]
   // StringLiteral PropertyNames
@@ -105,14 +105,14 @@ Map!{foo: 1, 'foo': 1, [Symbol('bar')]: 2, 3: 4, [{}]: 5}
 
 // Tagged Array Literals
 Set![1,2,3]
-=== Set.from({[Symbol.iterator]: function* () {
+=== Set[Symbol.from]({[Symbol.iterator]: function* () {
   // Nothing special here, except the argument is not an Array
   yield 1; yield 2; yield 3
 }})
 
 // Tagged Value Literals
 Some!1
-=== Some.from(1)
+=== Some[Symbol.from](1)
 ```
 
 ### Benefits
@@ -154,7 +154,7 @@ arrays and individual values is the correspondence to destructuring...
 When a user learns they can construct with one syntax, is becomes much easier to
 teach them how to destruct with it.
 
-While the common `.from()` method mechanism is what makes construction literals
+While the common `.[Symbol.from]()` method mechanism is what makes construction literals
 work, destructuring uses the standard iterator protocol through a
 `Symbol.valueOf` constructor method. If `Symbol.valueOf` is not present,
 `.valueOf()` is tried instead. If array or object-destructurng syntax is used


### PR DESCRIPTION
This PR changes the underlying construction protocol from `.from()` to `[Symbol.from]()`

### Rationale

I think using string keys for new protocols is risky, due to the high-collision nature of string keys. Namely this will manifest in a few issues:

 - `.from` becomes a pseudo reserved method name (similar to how `.then` is with the introduction of Promises)
 - existing libraries that use `.from` may need to change their semantics in order to accomodate this new syntax
 - I anticipate that users will expect `!` to be a shorthand for `.from` and so expect the reverse to be true - expecting any API with a `.from` static method to adhere to `!` semantics.

### How does this PR fix the problem?

By using a well-known Symbol instead of a well-known method name we solve the above problems because:

 - there is a (near) zero risk of colliding with existing APIs
 - I believe users are less expectant around the semantics of `[Symbol.*]` methods.
 - We pass no additional refactoring burden on library authors, and if their `.from` methods already match semantics, they can just alias the method.

